### PR TITLE
Change Track lifecycle.

### DIFF
--- a/src/MeLikey/WebAppBundle/Resources/client/src/models/player.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/models/player.coffee
@@ -7,7 +7,7 @@ define [
   'use strict'
 
   class Player extends Model
-  
+
     defaults:
       duration: 0
       loaded: 0
@@ -42,16 +42,19 @@ define [
       else if @vimeo?
         @playerWrapper = new VimeoWrapper _.extend(params, {vimeoID: @vimeo})
       else throw new Error "Unknown Track type, no compatible player found..."
-      @playerWrapper.initializeEngine()
 
     onReady: =>
+      console.debug "Player.onReady"
       @set 'ready', true
       if @autoplay then @play()
 
     play: ->
-      return if @disposed or (@get 'playing') or !@get 'ready'
-      @playerWrapper.play()
-      @set 'playing', true
+      return if @disposed or (@get 'playing')
+      if !@get 'ready'
+        @playerWrapper.initializeEngine()
+      else
+        @playerWrapper.play()
+        @set 'playing', true
 
     pause: ->
       return if @disposed or !(@get 'playing') or !@get 'ready'

--- a/src/MeLikey/WebAppBundle/Resources/client/src/models/track.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/models/track.coffee
@@ -6,7 +6,7 @@ define [
 
   class Track extends Model
 
-    # Static property and methods. 
+    # Static property and methods.
     # Tracks in the vault are cached, and can't be disposed.
     # The vault is kinda like a Store, but only for specific Tracks (those either currently playing, or in the radio playlist).
     @vault: {}
@@ -17,7 +17,7 @@ define [
     @flushVault: ->
       Track.vault = {}
 
-    autoplay: false
+    autoplay: true
     player: null
     urlRoot: Routing.generate('melikey_api_get_tracks')
 
@@ -36,7 +36,7 @@ define [
       _.extend this, options
       @initializePlayer()
       @once 'change:soundcloud change:youtube change:vimeo', @initializePlayer
-    
+
     dispose: ->
       return if @disposed
       unless Track.vault[@id]?
@@ -55,22 +55,18 @@ define [
 
     play: ->
       console.debug "Track.play"
-      if @player.get 'ready'
-        @player.play()
-      else
-        @listenToOnce @player, 'change:ready', @play
+      @player.play()
 
     onPlayerError: ->
       @publishEvent 'Track:error', this
 
     onPlayerPlayStateChange: ->
       if @player.get 'playing'
-        console.debug "coucou"
         @publishEvent 'Track:play', this
-        
+
     onPlayerFinish: ->
       @publishEvent 'Track:end', this
-        
+
     onPlayerReadyStateChange : ->
       if @player.get 'ready'
         @trigger 'Track:playerReady', @player

--- a/src/MeLikey/WebAppBundle/Resources/client/src/views/player-controls-view.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/views/player-controls-view.coffee
@@ -44,7 +44,6 @@ define [
         @$el.removeClass 'buffering'
 
     play: ->
-      debugger
       @model.play()
 
     pause: ->

--- a/src/MeLikey/WebAppBundle/Resources/client/src/views/playlist-item-view.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/views/playlist-item-view.coffee
@@ -15,7 +15,7 @@ define [
     initialize: ->
       @togglePlaying() if @model?
       @delegate 'click', ->
-        @model.player.play() if @model.player? and @model.player.get 'ready'
+        @model.play()
       @listenTo @model.player, 'change:playing', @togglePlaying
 
     togglePlaying: ->


### PR DESCRIPTION
Instead of sending API calls when a Track is instantiated, we wait until
the Track need to be played.
