### PR TITLE
Prevent the infinite scroll from freezing everything.

### DIFF
--- a/src/MeLikey/WebAppBundle/Resources/client/src/models/player.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/models/player.coffee
@@ -19,14 +19,12 @@ define [
     playerWrapper: null
 
     initialize: (attributes, options) ->
-      console.debug "Player.initialize"
       super
       options or= {}
       _.extend this, _.pick(options, 'autoplay', 'soundcloud', 'youtube', 'vimeo')
       @initializePlayerWrapper()
 
     initializePlayerWrapper: ->
-      console.debug "Player.initializePlayerWrapper"
       params =
         autoplay: @autoplay
         onError: @onError
@@ -44,7 +42,6 @@ define [
       else throw new Error "Unknown Track type, no compatible player found..."
 
     onReady: =>
-      console.debug "Player.onReady"
       @set 'ready', true
       if @autoplay then @play()
 

--- a/src/MeLikey/WebAppBundle/Resources/client/src/models/track.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/models/track.coffee
@@ -44,7 +44,6 @@ define [
         super
 
     initializePlayer: (options) ->
-      console.debug "Track.initializePlayer"
       player = @player
       if not player?
         @player = new Player {}, _.extend(@getAttributes(), {autoplay: @autoplay})
@@ -54,7 +53,6 @@ define [
         @listenTo @player, 'Player:error', @onPlayerError
 
     play: ->
-      console.debug "Track.play"
       @player.play()
 
     onPlayerError: ->

--- a/src/MeLikey/WebAppBundle/Resources/client/src/views/tracks-view.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/views/tracks-view.coffee
@@ -20,11 +20,8 @@ define [
       #used for endless scroll
       @loading = false
       @offset = 9999999 #so @loadTracks isn't called at at startup. Feels hacky though.
-      @on 'visibilityChange', ->
-        lastTrack = @$el.find('.track:last')
-        if lastTrack.length > 0
-          @offset = lastTrack.offset().top
-        else @offset = 9999999
+      # if we dont' debounce, the visibilitChanged is triggered o many times it freezes everything.
+      @on 'visibilityChange', _.debounce(@updateScrollOffset, 1000)
       # debouncing the scroll event prevents useless comptuations.
       $(window).scroll _.debounce(@scroll, 300)
       if @tags?
@@ -54,7 +51,6 @@ define [
         remove: false
         merge: false
         success: (tracks) =>
-          @loading = false
           @reachedTheEnd = tracks.length == data.offset
       }
 
@@ -71,3 +67,10 @@ define [
         @collection.reset filtered
         @activeTag = tag
         @loadTracks()
+
+    updateScrollOffset: ->
+      lastTrack = @$el.find('.track:last')
+      if lastTrack.length > 0
+        @offset = lastTrack.offset().top
+      else @offset = 9999999
+      @loading = false


### PR DESCRIPTION
Listening to visibityChange without debouncing is not a good idea.
The whole thing still feels hacky though.
