### PR TITLE
[front] add cookie support in radio manager

### DIFF
--- a/src/MeLikey/WebAppBundle/Resources/client/bower.json
+++ b/src/MeLikey/WebAppBundle/Resources/client/bower.json
@@ -23,6 +23,7 @@
     "handlebars": "~1.1.2",
     "requirejs-text": "~2.0.9",
     "chaplin": "~0.11.3",
-    "malihu-custom-scrollbar-plugin": "git://github.com/malihu/malihu-custom-scrollbar-plugin.git"
+    "malihu-custom-scrollbar-plugin": "git://github.com/malihu/malihu-custom-scrollbar-plugin.git",
+    "cookies-js": "~0.3.1"
   }
 }

--- a/src/MeLikey/WebAppBundle/Resources/client/src/controllers/site-controller.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/controllers/site-controller.coffee
@@ -21,6 +21,10 @@ define [
       @subscribeEvent 'GlobalPlayer:prev', @prev
       @subscribeEvent 'Track:end', @next
       @subscribeEvent 'Track:error', @next
+      @subscribeEvent 'Track:play', @onTrackPlay
+
+    onTrackPlay: (track) ->
+      @publishEvent 'Radio:newTrackPlaying', track
 
     next: (track) ->
       Chaplin.mediator.radioManager.next track

--- a/src/MeLikey/WebAppBundle/Resources/client/src/controllers/tracks-controller.coffee
+++ b/src/MeLikey/WebAppBundle/Resources/client/src/controllers/tracks-controller.coffee
@@ -39,6 +39,9 @@ define [
           $('#main-loader').removeClass('loading')
       @view = new TrackView options
 
+    # Don't send a 'Radio:newTrackPlaying' event when track starts playing
+    onTrackPlay: ->
+
     # Override default behaviour on click on the Global player Next button.
     next: (track) ->
       return super if not @tracks

--- a/src/MeLikey/WebAppBundle/Resources/views/WebApp/index.html.twig
+++ b/src/MeLikey/WebAppBundle/Resources/views/WebApp/index.html.twig
@@ -34,7 +34,8 @@
                     soundcloudSDK: 'http://connect.soundcloud.com/sdk',
                     twig: '../vendor/twig.dev',
                     scrollbar: '../vendor/malihu-custom-scrollbar-plugin/jquery.mCustomScrollbar.concat.min',
-                    facebookSDK: '//connect.facebook.net/en_US/all'
+                    facebookSDK: '//connect.facebook.net/en_US/all',
+                    cookiesjs: '../vendor/cookies-js/src/cookies'
                 },
                 shim: {
                     underscore: {


### PR DESCRIPTION
The manager now sets a cookie when playing a track, and retrieves it
when loading the playlist, to start where the user left off.
- using cookie-js.
- The manager is not responsible for knowing if a new Track playing is
  in the radio playlist, or somewhere else. It's the current controller
  that decides if it plays radio tracks or not (default behaviour is
  that it's a radio track).
- Incidentally, the radio manager doesn't fire Radio:newTrackPlaying
  events, it's the current controller that does (it feels weird though).
